### PR TITLE
Bug Fixes

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,7 +46,8 @@ class Commands:
                 tz = timezone.parse_timezone(params[0])
             except TypeError:
                 tz = False
-            if tz:
+            if type(tz) != bool:#check if it's a bool
+                #since the timezone could be "0"
                 user = database.get_user(message.author.id)
                 if not user:
                     database.add_user(message.author.id, tz)
@@ -63,27 +64,25 @@ class Commands:
                     if tz > 0:
                         await message.channel.send(
                             'Timezone has been updated to UTC+%d for %s.' % (tz, message.author.name))
-                        return
                     else:
                         await message.channel.send(
                             'Timezone has been updated to UTC%d for %s.' % (tz, message.author.name))
-                        return
 
-            # if previous timezone existed
-            if old_tz:
-                # calculate change in time_zones
-                tz_change = old_tz - tz
-                # go through each interval
-                for i in old_tz:
-                    # remove the old interval
-                    database.delete_interval(i.get_id())
-                    # get new interval
-                    new_interval = alter_timezone(i.start_day, i.start_hour, i.end_day, i.end_hour, tz_change)
-                    # add the new interval
-                    database.add_interval(message.author.id, new_interval[0], new_interval[2],
-                                          new_interval[1], new_interval[3])
-                await message.channel.send('updated all previous intervals')
-                return
+                # if previous timezone existed
+                if old_tz:
+                    # calculate change in time_zones
+                    tz_change = old_tz - tz
+                    # go through each interval
+                    for i in old_tz:
+                        # remove the old interval
+                        database.delete_interval(i.get_id())
+                        # get new interval
+                        new_interval = alter_timezone(i.start_day, i.start_hour, i.end_day, i.end_hour, tz_change)
+                        # add the new interval
+                        database.add_interval(message.author.id, new_interval[0], new_interval[2],
+                                              new_interval[1], new_interval[3])
+                    await message.channel.send('updated all previous intervals')
+                    return
             else:
                 await message.channel.send('%s is not a valid time zone.' % params[0])
                 return

--- a/main.py
+++ b/main.py
@@ -46,8 +46,8 @@ class Commands:
                 tz = timezone.parse_timezone(params[0])
             except TypeError:
                 tz = False
-            if type(tz) != bool:#check if it's a bool
-                #since the timezone could be "0"
+            if type(tz) != bool:# check if it's a bool
+                # since the timezone could be "0"
                 user = database.get_user(message.author.id)
                 if not user:
                     database.add_user(message.author.id, tz)


### PR DESCRIPTION
Fixed "if tz:" in 'set_time_zn()', to "if type(tz) != bool:". This now allows for the timezone to be equal to 0(gmt, utc+0, ect...), as previously, the if statement would detect any "0" as not being a valid timezone.

The second fix was of the "if old_tz:" statement, also within 'set_time_zn()'. It was one indentation too low, and was liked up to the invalid timezone "else" statement. I simply indented it once more.

---END---